### PR TITLE
fix unauthorized exception

### DIFF
--- a/src/Nager.PublicSuffix/FileCacheProvider.cs
+++ b/src/Nager.PublicSuffix/FileCacheProvider.cs
@@ -31,6 +31,15 @@ namespace Nager.PublicSuffix
 
             var tempPath = Path.GetTempPath();
             this._cacheFilePath = Path.Combine(tempPath, cacheFileName);
+
+            var poolId = Environment.GetEnvironmentVariable("APP_POOL_ID", EnvironmentVariableTarget.Process);
+
+            if (!string.IsNullOrEmpty(poolId))
+            {
+                Directory.CreateDirectory(Path.Combine(tempPath, poolId));
+
+                this._cacheFilePath = Path.Combine(tempPath, poolId, cacheFileName);
+            }
         }
 
         ///<inheritdoc/>


### PR DESCRIPTION
Path.GetTempPath checks the existance of some environment variables and return the first path found. If none is found, then it returns the windows temp directory ( C:/Windows/Temp ).
In sites hosted in IIS none of the environment variables is present so the windows temp directory is used.
In windows temp directory all users can create files. By default, users can access or modify only the files they created.

So the problem is that the first IIS website will create the "publicsuffixcache.dat" file in C:/Windows/Temp/ directory with read/write permissions to the application pool assigned to this website. Any other IIS website running under a different application pool will get AnauthorizedException.