### PR TITLE
Add provider combinator

### DIFF
--- a/src/Nager.PublicSuffix.UnitTest/StringTldRuleProviderTest.cs
+++ b/src/Nager.PublicSuffix.UnitTest/StringTldRuleProviderTest.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Nager.PublicSuffix.UnitTest;
+
+[TestClass]
+public class StringTldRuleProviderTest
+{
+    [TestMethod]
+    public async Task SimpleTldStringListTest()
+    {
+        const string rulesInText = @"
+                foo.com
+                !bar.com
+                !foo.bar.com";
+
+        var tldRuleProvider = new StringTldRuleProvider(rulesInText);
+        var rules = await tldRuleProvider.BuildAsync();
+        Assert.IsNotNull(rules);
+        Assert.AreEqual(3, rules.Count());
+    }
+}

--- a/src/Nager.PublicSuffix.UnitTest/TldRuleProviderCombinatorTest.cs
+++ b/src/Nager.PublicSuffix.UnitTest/TldRuleProviderCombinatorTest.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Nager.PublicSuffix.UnitTest;
+
+[TestClass]
+public class TldRuleProviderCombinatorTest
+{
+    [TestMethod]
+    public void DistinctByTest()
+    {
+        var r1 = new TldRule("foo");
+        var r3 = new TldRule("bar");
+        var r4 = new TldRule("foo.bar");
+
+        var seq = new[] { r1, r1, r3, r4, r3 };
+        var seqDistinct = seq.DistinctBy(x => x.Name).ToArray();
+
+        Assert.IsTrue(seqDistinct.Count() == 3);
+    }
+
+    [TestMethod]
+    public async Task CombinatorIdempotenceTest()
+    {
+        const string rulesInText = @"
+                !bar.com
+                !foo.bar.com
+                foo.com";
+
+        var provider1 = new StringTldRuleProvider(rulesInText);
+        var provider2 = new StringTldRuleProvider(rulesInText);
+        var provider = new TldRuleProviderCombinator(provider1, provider2);
+
+        var rules1 = (await provider1.BuildAsync()).ToArray();
+        var rules2 = (await provider2.BuildAsync()).ToArray();
+        var rules = (await provider.BuildAsync()).ToArray();
+
+        Assert.IsNotNull(rules);
+        Assert.IsTrue(rules.SequenceEqual(rules1));
+        Assert.IsTrue(rules.SequenceEqual(rules2));
+    }
+    [TestMethod]
+    public async Task CombinatorSetExtensionTest()
+    {
+        const string rulesInText1 = @"
+                !bar.com
+                foo.com";
+        const string rulesInText2 = @"
+                !foo.bar.com
+                foo.com";
+
+        var provider1 = new StringTldRuleProvider(rulesInText1);
+        var provider2 = new StringTldRuleProvider(rulesInText2);
+        var provider = new TldRuleProviderCombinator(provider1, provider2);
+        
+        var rules = (await provider.BuildAsync()).ToArray();
+
+        Assert.IsNotNull(rules);
+        Assert.IsTrue(rules.Count() == 3);
+        Assert.IsTrue(rules.Count(x => x.Name == "bar.com")==1);
+        Assert.IsTrue(rules.Count(x => x.Name == "foo.com")==1);
+        Assert.IsTrue(rules.Count(x => x.Name == "foo.bar.com")==1);
+    }
+}

--- a/src/Nager.PublicSuffix/StringTldRuleProvider.cs
+++ b/src/Nager.PublicSuffix/StringTldRuleProvider.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nager.PublicSuffix
+{
+    /// <summary>
+    /// StringTldRuleProvider
+    /// </summary>
+    public class StringTldRuleProvider : ITldRuleProvider
+    {
+        private readonly string _rules;
+    
+        /// <summary>
+        /// StringTldRuleProvider
+        /// </summary>
+        /// <param name="rules"></param>
+        public StringTldRuleProvider(string rules)
+        {
+            _rules = rules;
+        }
+
+        ///<inheritdoc/>
+        public Task<IEnumerable<TldRule>> BuildAsync()
+        {
+            var ruleParser = new TldRuleParser();
+            var rules = ruleParser.ParseRules(_rules);
+            return Task.FromResult(rules);
+        }
+    }
+}

--- a/src/Nager.PublicSuffix/TldRule.cs
+++ b/src/Nager.PublicSuffix/TldRule.cs
@@ -81,5 +81,25 @@ namespace Nager.PublicSuffix
         {
             return this.Name;
         }
+        private bool Equals(TldRule other)
+        {
+            return Name == other.Name;
+        }
+
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TldRule)obj);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return (Name != null ? Name.GetHashCode() : 0);
+        }
     }
 }

--- a/src/Nager.PublicSuffix/TldRuleProviderCombinator.cs
+++ b/src/Nager.PublicSuffix/TldRuleProviderCombinator.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nager.PublicSuffix
+{
+
+    /// <summary>
+    /// Constructs a new TilRuleProvider by combining providerA and providerB
+    /// </summary>
+    public class TldRuleProviderCombinator : ITldRuleProvider
+    {
+        private readonly ITldRuleProvider _providerA;
+        private readonly ITldRuleProvider _providerB;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="providerA"></param>
+        /// <param name="providerB"></param>
+        public TldRuleProviderCombinator(ITldRuleProvider providerA, ITldRuleProvider providerB)
+        {
+            _providerA = providerA;
+            _providerB = providerB;
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<TldRule>> BuildAsync()
+        {
+            var rulesA = await _providerA.BuildAsync();
+            var rulesB = await _providerB.BuildAsync();
+
+            if (rulesA == null) return rulesB;
+            if (rulesB == null) return rulesA;
+            return Combine(rulesA, rulesB);
+        }
+
+        private static IEnumerable<TldRule> Combine(IEnumerable<TldRule> rulesA, IEnumerable<TldRule> rulesB)
+        {
+            var combined = 
+                    rulesA
+                        .Concat(rulesB)
+                        .OrderBy(x=>x, new TldRuleComparer())
+                        .DistinctBy(x=>x.Name)
+                ;
+            return combined;
+
+        }
+    }
+
+    internal static class EnumerableExtensions
+    {
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector)
+        {
+            var set = new HashSet<TKey>();
+
+            foreach (var e in source)
+            {
+                if (set.Add(keySelector(e)))
+                {
+                    yield return e;
+                }
+            }
+        }
+    }
+    internal class TldRuleComparer : IComparer<TldRule>
+    {
+        public int Compare(TldRule x, TldRule y)
+        {
+            if (x == null && y == null) return 0;
+            if (x == null) return -1;
+            if (y == null) return 1;
+            
+            // https://github.com/publicsuffix/list/wiki/Format
+            var xReversed = string.Join(".", x.Name.Split('.').Reverse());
+            var yReversed = string.Join(".", y.Name.Split('.').Reverse());
+            return string.CompareOrdinal(xReversed, yReversed);
+        }
+    }
+}


### PR DESCRIPTION
Hello,
I created a pull request with a few minor improvements:

- I created a rules combinator that allows multiple rule providers into one. This way you can e.g. combine the global PublicSuffix list with a local/private one.
- I created a rule provider that reads its rules from a string of text. This way you can use hard-coded lists but also makes testing easy because there is no need to access files on the file system or connect to the global public suffix list.
- I added Equals methods to TldRule to make rules better comparable (two rules with same Name property are considered equal)

I hope you like these enhancements and that you will merge them into a new version of your nice library.

Happy coding!
Merijn