### PR TITLE
Rename CreareDomainDataStructure to CreateDomainDataStructure

### DIFF
--- a/src/Nager.PublicSuffix/RuleProviders/BaseRuleProvider.cs
+++ b/src/Nager.PublicSuffix/RuleProviders/BaseRuleProvider.cs
@@ -25,7 +25,7 @@ namespace Nager.PublicSuffix.RuleProviders
         /// Create a DomainDataStructure
         /// </summary>
         /// <param name="rules"></param>
-        protected void CreareDomainDataStructure(IEnumerable<TldRule> rules)
+        protected void CreateDomainDataStructure(IEnumerable<TldRule> rules)
         {
             var domainDataStructure = new DomainDataStructure("*", new TldRule("*"));
             domainDataStructure.AddRules(rules);

--- a/src/Nager.PublicSuffix/RuleProviders/CachedHttpRuleProvider.cs
+++ b/src/Nager.PublicSuffix/RuleProviders/CachedHttpRuleProvider.cs
@@ -90,7 +90,7 @@ namespace Nager.PublicSuffix.RuleProviders
             var ruleParser = new TldRuleParser();
             var rules = ruleParser.ParseRules(ruleData);
 
-            base.CreareDomainDataStructure(rules);
+            base.CreateDomainDataStructure(rules);
 
             return true;
         }

--- a/src/Nager.PublicSuffix/RuleProviders/LocalFileRuleProvider.cs
+++ b/src/Nager.PublicSuffix/RuleProviders/LocalFileRuleProvider.cs
@@ -36,7 +36,7 @@ namespace Nager.PublicSuffix.RuleProviders
             var domainDataStructure = new DomainDataStructure("*", new TldRule("*"));
             domainDataStructure.AddRules(rules);
 
-            base.CreareDomainDataStructure(rules);
+            base.CreateDomainDataStructure(rules);
 
             return true;
         }

--- a/src/Nager.PublicSuffix/RuleProviders/SimpleHttpRuleProvider.cs
+++ b/src/Nager.PublicSuffix/RuleProviders/SimpleHttpRuleProvider.cs
@@ -102,7 +102,7 @@ namespace Nager.PublicSuffix.RuleProviders
             var ruleParser = new TldRuleParser();
             var rules = ruleParser.ParseRules(ruleData);
 
-            base.CreareDomainDataStructure(rules);
+            base.CreateDomainDataStructure(rules);
 
             return true;
         }

--- a/src/Nager.PublicSuffix/RuleProviders/StaticRuleProvider.cs
+++ b/src/Nager.PublicSuffix/RuleProviders/StaticRuleProvider.cs
@@ -25,7 +25,7 @@ namespace Nager.PublicSuffix.RuleProviders
         /// <param name="rules"></param>
         public StaticRuleProvider(IEnumerable<TldRule> rules)
         {
-            base.CreareDomainDataStructure(rules);
+            base.CreateDomainDataStructure(rules);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This pull request contains just the fix of the typo in CreareDomainDataStructure