### PR TITLE
Introduce MemoryCacheProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ var isValid = domainParser.IsValidDomain("sub.test.co.uk");
 // after -> var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHttpClient(); //Required for CachedHttpRuleProvider
+// You can use LocalFileSystemCacheProvider to store the cache in your as a local file - improves memory usage
 builder.Services.AddSingleton<ICacheProvider, LocalFileSystemCacheProvider>();
+// Or you  can use with is recommended for Azure functions or application where you don't have files access permission
+// builder.Services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
 builder.Services.AddSingleton<IRuleProvider, CachedHttpRuleProvider>();
 builder.Services.AddSingleton<IDomainParser, DomainParser>();
 

--- a/src/Nager.PublicSuffix.TestConsole/Program.cs
+++ b/src/Nager.PublicSuffix.TestConsole/Program.cs
@@ -3,14 +3,16 @@ using Microsoft.Extensions.Logging;
 using Nager.PublicSuffix;
 using Nager.PublicSuffix.RuleProviders;
 
-Console.WriteLine("Run - DemoCachedHttpRuleProviderAsync");
-await DemoCachedHttpRuleProviderAsync();
+Console.WriteLine("Run - DemoLocalFileCachedHttpRuleProviderAsync");
+await DemoLocalFileCachedHttpRuleProviderAsync();
+Console.WriteLine("Run - DemoMemoryCachedHttpRuleProviderAsync");
+await DemoMemoryCachedHttpRuleProviderAsync();
 Console.WriteLine("Run - DemoSimpleHttpRuleProviderAsync");
 await DemoSimpleHttpRuleProviderAsync();
 Console.WriteLine("Run - DemoLocalFileRuleProviderAsync");
 await DemoLocalFileRuleProviderAsync();
 
-async Task DemoCachedHttpRuleProviderAsync()
+async Task DemoLocalFileCachedHttpRuleProviderAsync()
 {
     using var loggerFactory = LoggerFactory.Create(builder =>
     {
@@ -28,6 +30,30 @@ async Task DemoCachedHttpRuleProviderAsync()
 
     using var httpClient = new HttpClient();
     var cacheProvider = new Nager.PublicSuffix.RuleProviders.CacheProviders.LocalFileSystemCacheProvider();
+
+    var ruleProvider = new CachedHttpRuleProvider(ruleProviderLogger, configuration, cacheProvider, httpClient);
+
+    await CheckAsync(ruleProvider);
+}
+
+async Task DemoMemoryCachedHttpRuleProviderAsync()
+{
+    using var loggerFactory = LoggerFactory.Create(builder =>
+    {
+        builder.AddConsole();
+    });
+
+    var ruleProviderLogger = loggerFactory.CreateLogger<CachedHttpRuleProvider>();
+
+    IConfiguration configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(new List<KeyValuePair<string, string?>>
+        {
+            new("Nager:PublicSuffix:DataUrl", "https://publicsuffix.org/list/public_suffix_list.dat")
+        })
+        .Build();
+
+    using var httpClient = new HttpClient();
+    var cacheProvider = new Nager.PublicSuffix.RuleProviders.CacheProviders.MemoryCacheProvider();
 
     var ruleProvider = new CachedHttpRuleProvider(ruleProviderLogger, configuration, cacheProvider, httpClient);
 

--- a/src/Nager.PublicSuffix.UnitTest/CacheProviders/MemoryCacheProviderTest.cs
+++ b/src/Nager.PublicSuffix.UnitTest/CacheProviders/MemoryCacheProviderTest.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.PublicSuffix.RuleProviders.CacheProviders;
+
+namespace Nager.PublicSuffix.UnitTest.CacheProviders;
+
+[TestClass]
+public class MemoryCacheProviderTest
+{
+    private MemoryCacheProvider _target;
+    
+    [TestInitialize]
+    public void Initialize()
+    {
+        _target = new MemoryCacheProvider();
+    }
+    
+    [TestMethod]
+    public async Task No_Data_Set()
+    {   
+        Assert.IsFalse(_target.IsCacheValid());
+        Assert.IsNull(await _target.GetAsync()!);
+    }
+    
+    [TestMethod]
+    public async Task Valid_Data_Set()
+    {
+        await _target.SetAsync("d");
+        Assert.IsTrue(_target.IsCacheValid());
+        Assert.AreEqual("d", await _target.GetAsync()!);
+    }
+    
+    [TestMethod]
+    public async Task Expired_Data_Set()
+    {
+        _target = new MemoryCacheProvider(TimeSpan.FromMilliseconds(500));
+        await _target.SetAsync("d");
+        await Task.Delay(1000);
+        Assert.IsFalse(_target.IsCacheValid());
+        Assert.IsNull(await _target.GetAsync()!);
+    }
+}

--- a/src/Nager.PublicSuffix/RuleProviders/CacheProviders/MemoryCacheProvider.cs
+++ b/src/Nager.PublicSuffix/RuleProviders/CacheProviders/MemoryCacheProvider.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Nager.PublicSuffix.RuleProviders.CacheProviders
+{
+    /// <summary>
+    /// MemoryCacheProvider, uses memory to cache the data, mostly used for testing Azure functions
+    /// </summary>
+    public class MemoryCacheProvider : ICacheProvider
+    {
+        private readonly TimeSpan _timeToLive;
+        private DateTime _lastWriteTimeUtc;
+        private string? _data;
+
+        /// <summary>
+        /// MemoryCacheProvider
+        /// </summary>
+        /// <param name="cacheTimeToLive"></param>
+        public MemoryCacheProvider(TimeSpan? cacheTimeToLive = null)
+        {
+            _timeToLive = cacheTimeToLive ?? TimeSpan.FromDays(1);
+        }
+
+        /// <inheritdoc/>
+        public bool IsCacheValid()
+        {
+            return _lastWriteTimeUtc > DateTime.UtcNow.Subtract(_timeToLive);
+        }
+
+        /// <inheritdoc/>
+        public Task<string?> GetAsync()
+        {
+            return Task.FromResult(IsCacheValid() ? _data : null);
+        }
+
+        /// <inheritdoc/>
+        public Task SetAsync(string data)
+        {
+            _data = data;
+            _lastWriteTimeUtc = DateTime.UtcNow;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
**Description**
This PR extends the Nager.PublicSuffix to include a MemoryCache option. Due to Azure restrictions that prevent using LocalFileCache, I implemented a MemoryCache to ensure efficient caching within the application.

**Changes**
I added a new MemoryCache class to handle in-memory caching.
Integrated MemoryCache into the existing caching mechanism, allowing it to be used as an alternative to LocalFileCache.
I updated relevant documentation to reflect the new caching option.
Added unit tests for the MemoryCache to ensure reliability and performance.
Motivation and Context
Azure's restrictions on using LocalFileCache necessitated an alternative caching strategy. The MemoryCache provides a viable solution, enabling caching functionality while complying with Azure's limitations. This improvement will enhance performance and maintain the flexibility of the caching system within the library.

**How Has This Been Tested?**
Added unit tests specifically for MemoryCache to verify its functionality.
Extended the `Program.cs` to make a test in a similar fashion as it's done with the LocalFile cache.